### PR TITLE
Switch input in circuit to match abi used in typescript

### DIFF
--- a/circuits/src/main.nr
+++ b/circuits/src/main.nr
@@ -1,4 +1,4 @@
-fn main(guess: pub u4, report_hit: pub u4, ship: u4) {
+fn main(guess: pub u4, ship: u4, report_hit: pub u4) {
     // Noir doesn't allow boolean inputs so we treat 0 as a miss and 1 as a hit.
     constrain (report_hit == 0) | (report_hit == 1);
     let report_hit_flag = report_hit == 1;

--- a/test/inequality.test.ts
+++ b/test/inequality.test.ts
@@ -68,4 +68,9 @@ describe('Tests using typescript wrapper', function () {
       itAcceptsTheProof({ guess: 2, ship: 1, report_hit: 0 });
     });
   });
+
+  context('invalid hit report', () => {
+    itRejectsTheProof({ guess: 2, ship: 1, report_hit: 2 });
+  });
+
 });


### PR DESCRIPTION
The error with the boolean is not due to the fact that Noir does not allow boolean inputs. Rather the abi specified in Typescript must be in the same order of the ABI specified in Noir, even if the names of the inputs match. This is not necessary ideal for developer experience, but right now the ABI will be in deterministic order. 

I simply switched the order of the inputs in the circuit to match what is specified in the Typescript ABI. I also added a test to show how the invalid input for `report_hit` causes a failed proof. 